### PR TITLE
Support x-www-form-urlencoded with UTF-8 charset

### DIFF
--- a/src/main/java/com/lavacorp/beautefly/webstore/security/SecurityController.java
+++ b/src/main/java/com/lavacorp/beautefly/webstore/security/SecurityController.java
@@ -21,7 +21,11 @@ import org.hibernate.exception.ConstraintViolationException;
 @Path("/account")
 @ApplicationScoped
 @Transactional
-@Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_FORM_URLENCODED})
+@Consumes({
+        MediaType.APPLICATION_JSON,
+        MediaType.APPLICATION_FORM_URLENCODED,
+        MediaType.APPLICATION_FORM_URLENCODED + "; charset=UTF-8"
+})
 @Produces(MediaType.APPLICATION_JSON)
 public class SecurityController {
     @Inject


### PR DESCRIPTION
Requests with the Content-Type: `application/x-www-form-urlencoded; charset=UTF-8` does not get handled unless utf-8 charset is explicitly specified in the `@Consumes` annotation.