### PR TITLE
Fix https://github.com/makan-kencing/beautefly-webstore/pull/6

### DIFF
--- a/src/main/java/com/lavacorp/beautefly/webstore/security/SecurityController.java
+++ b/src/main/java/com/lavacorp/beautefly/webstore/security/SecurityController.java
@@ -21,11 +21,7 @@ import org.hibernate.exception.ConstraintViolationException;
 @Path("/account")
 @ApplicationScoped
 @Transactional
-@Consumes({
-        MediaType.APPLICATION_JSON,
-        MediaType.APPLICATION_FORM_URLENCODED,
-        MediaType.APPLICATION_FORM_URLENCODED + "; charset=UTF-8"
-})
+@Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_FORM_URLENCODED})
 @Produces(MediaType.APPLICATION_JSON)
 public class SecurityController {
     @Inject

--- a/src/main/java/com/lavacorp/beautefly/webstore/utils/FormBindingMessageBodyReader.java
+++ b/src/main/java/com/lavacorp/beautefly/webstore/utils/FormBindingMessageBodyReader.java
@@ -30,8 +30,9 @@ public class FormBindingMessageBodyReader<T> implements MessageBodyReader<T> {
 
     @Override
     public boolean isReadable(final Class<?> type, final Type genericType, final Annotation[] annotations, final MediaType mediaType) {
-        return !type.isAssignableFrom(Form.class) && !type.isAssignableFrom(Collections.class)
-                && mediaType.equals(MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+        if (type.isAssignableFrom(Form.class) || type.isAssignableFrom(Collections.class))
+            return false;
+        return mediaType.isCompatible(MediaType.APPLICATION_FORM_URLENCODED_TYPE);
     }
 
     @Override


### PR DESCRIPTION
Explicit charset definition is not the solution. `FormBindingMessageBodyReader` need to return `True` when passed a `APPLICATION_FORM_URLENCODED_TYPE` with utf-8 charset in `isReadable()`